### PR TITLE
fixed typo in t.test example

### DIFF
--- a/intro-to-r-bioc/L1.2-tidy-r-intro.Rmd
+++ b/intro-to-r-bioc/L1.2-tidy-r-intro.Rmd
@@ -188,7 +188,7 @@ expects the data as the second argument. To adapt `t.test()` for use,
 we need to explicitly indicate that the data should be the second
 argument. One way of doing this is to use the special symbol `.` to
 represent the location of the incoming data, invoking `t.test(age ~
-sex, data = .)`:
+sex, data = _)`:
 
 ```{r, eval = FALSE}
 pdata |>


### PR DESCRIPTION
replaced . with _ in text, to match the code example (. only works with magrittr)